### PR TITLE
Prevent version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["concurrency", "asynchronous"]
 
 [dependencies]
 lock_api = "0.3"
-parking_lot = "0.9"
+parking_lot = "0.10"
 crossbeam-queue = "0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-//Re-export `parking_lot` to avoid version mismatch
-pub use parking_lot;
-
 //! # future-parking_lot
 //!
 //! A simple Future implementation for parking_lot
@@ -18,3 +15,6 @@ pub use parking_lot;
 pub mod mutex;
 /// parking_lot::RwLock Future implementation
 pub mod rwlock;
+
+//Re-export `parking_lot` to avoid version mismatch
+pub use parking_lot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
+//Re-export `parking_lot` to avoid version mismatch
+pub use parking_lot;
+
 //! # future-parking_lot
 //!
 //! A simple Future implementation for parking_lot


### PR DESCRIPTION
By re-exporting `parking_lot` in the crate root it's possible for users to just use the `parking_lot` version that this crate implements the traits for, thus preventing confusing errors that arise when the user chooses a different version of `parking_lot`.